### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The latest version of the compiled and minified script `jclic.min.js` is current
 
 - https://unpkg.com/jclic/dist/jclic.min.js
 - https://clic.xtec.cat/dist/jclic.js/jclic.min.js
-- https://cdn.jsdelivr.net/jclic.js/latest/jclic.min.js
+- https://cdn.jsdelivr.net/npm/jclic@latest/dist/jclic.min.js
 
 ## Sponsors that make possible JClic.js
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "HTML5 player for JClic activities",
   "version": "0.1.49",
   "main": "src/JClic.js",
+  "jsdelivr": "dist/jclic.min.js",
   "homepage": "http://projectestac.github.io/jclic.js",
   "readmeFilename": "README.md",
   "author": "Francesc Busquets <francesc@gmail.com>",


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jclic.

Feel free to ping me if you have any questions regarding this change.